### PR TITLE
static item bases, only require 'static for (de)serialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,55 +12,61 @@ addons:
 
 env:
   global:
-    - FMT_VERSION=nightly-2018-07-17
-    - DOCS_RS_VERSION=nightly-2018-07-07 # https://docs.rs/about
+    - FMT_VERSION=nightly-2018-07-30
+    - CLIPPY_VERSION=nightly-2018-07-30
+    - DOCS_RS_VERSION=nightly-2018-06-03 # https://github.com/onur/docs.rs/blob/32102ce458b34f750ef190182116d9583491a64b/Vagrantfile#L50
 
 matrix:
   include:
     - os: linux
       dist: precise
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" DIST="precise"
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="precise" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: linux
       dist: trusty
       sudo: false
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" DIST="trusty"
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: linux
       dist: trusty
       sudo: required # https://docs.travis-ci.com/user/reference/overview/
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" DIST="trusty"
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: osx
       osx_image: xcode6.4 # https://docs.travis-ci.com/user/reference/osx/
-      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin"
+      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin" RUSTFLAGS_VARIATIONS=";" # https://github.com/rust-lang/rust/pull/49219 ;-Cpanic=abort
     - os: osx
       osx_image: xcode8.3
-      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin"
+      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin" RUSTFLAGS_VARIATIONS=";" # ;-Cpanic=abort
     - os: osx
       osx_image: xcode9.4
-      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin"
+      env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin" RUSTFLAGS_VARIATIONS=";" # ;-Cpanic=abort
 
 before_script: |
   ( set -o errexit;set -o pipefail; set -o xtrace;set -o nounset;
     for TARGET in $BUILD $RUN; do [ "$TARGET" = $(rustup target list | grep default | grep -o -e '^[^ ]\+') ] || travis_retry rustup target add "$TARGET"; done
     travis_retry rustup toolchain add $FMT_VERSION
+    travis_retry rustup toolchain add $CLIPPY_VERSION
     travis_retry rustup component add rustfmt-preview --toolchain $FMT_VERSION
+    travis_retry rustup component add clippy-preview --toolchain $CLIPPY_VERSION
     travis_retry rustup toolchain add $DOCS_RS_VERSION
     for TARGET in $BUILD $RUN; do [ "$TARGET" = $(rustup target list | grep default | grep -o -e '^[^ ]\+') ] || travis_retry rustup target add --toolchain $DOCS_RS_VERSION "$TARGET"; done
   )
 script: |
   ( set -o errexit;set -o pipefail; set -o xtrace;set -o nounset;
     cargo +$FMT_VERSION fmt -- --check
-    for TARGET in $BUILD $RUN; do (
-      [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && exit 0 # export RUSTFLAGS="-C linker=rust-lld -Z linker-flavor=ld.lld"
-      cargo build --verbose --target "$TARGET" --lib --tests
-      cargo build --verbose --target "$TARGET" --lib --tests --release
-    ); done
-    for TARGET in $RUN; do (
-      [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && exit 0 # export RUSTFLAGS="-C linker=rust-lld -Z linker-flavor=ld.lld"
-      RUST_BACKTRACE=full cargo test --target "$TARGET"
-      RUST_BACKTRACE=full cargo test --target "$TARGET" --release
-    ); done
+    cargo +$CLIPPY_VERSION clippy --lib --tests -- -D warnings
+    OLD_IFS=$IFS IFS=";"; for RUSTFLAGS in $RUSTFLAGS_VARIATIONS; do ( IFS=$OLD_IFS
+      export RUSTFLAGS
+      for TARGET in $BUILD $RUN; do (
+        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld"
+        cargo build --verbose --target "$TARGET" --lib --tests
+        cargo build --verbose --target "$TARGET" --lib --tests --release
+      ); done
+      for TARGET in $RUN; do (
+        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld"
+        RUST_BACKTRACE=full cargo test --target "$TARGET"
+        RUST_BACKTRACE=full cargo test --target "$TARGET" --release
+      ); done
+    ); done; IFS=$OLD_IFS
     for TARGET in $BUILD $RUN; do
-      cargo +$DOCS_RS_VERSION doc --no-deps --target "$TARGET" &>/dev/null
       cargo +$DOCS_RS_VERSION doc --no-deps --target "$TARGET" --release &>/dev/null
     done
   )

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 A type to wrap `&'static` references such that they can be safely sent between
 other processes running the same binary.
 
-References are adjusted relative to a base when (de)serialised, which accounts
-for binaries being dynamically loaded at different addresses under multiple
-invocations.
+References are adjusted relative to a base when (de)serialised, which is what
+enables it to work across binaries that are dynamically loaded at different
+addresses under multiple invocations.
 
 It being the same binary is checked by serialising the
 [`build_id`](https://docs.rs/build_id) alongside the relative pointer, which is
@@ -24,7 +24,7 @@ validated at deserialisation.
 ```rust
 let x: &'static [u16;4] = &[2,3,5,8];
 // unsafe as it's up to the user to ensure the reference is into static memory
-let relative = unsafe{Pointer::from(x)};
+let relative = unsafe{Data::from(x)};
 // send `relative` to remote...
 ```
 ### Remote process

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 //! **[Crates.io](https://crates.io/crates/relative) │ [Repo](https://github.com/alecmocatta/relative)**
 //!
 //! References are adjusted relative to a base when (de)serialised, which
-//! accounts for binaries being dynamically loaded at different addresses under
-//! multiple invocations.
+//! is what enables it to work across binaries that are dynamically loaded at
+//! different addresses under multiple invocations.
 //!
 //! It being the same binary is checked by serialising the
 //! [`build_id`](https://docs.rs/build_id) alongside the relative pointer, which
@@ -17,14 +17,14 @@
 //! # use relative::*;
 //! let x: &'static [u16;4] = &[2,3,5,8];
 //! // unsafe as it's up to the user to ensure the reference is into static memory
-//! let relative = unsafe{Pointer::from(x)};
+//! let relative = unsafe{Data::from(x)};
 //! // send `relative` to remote...
 //! ```
 //! ### Remote process
 //! ```
 //! # use relative::*;
 //! # let x: &'static [u16;4] = &[2,3,5,8];
-//! # let relative = unsafe{Pointer::from(x)};
+//! # let relative = unsafe{Data::from(x)};
 //! // receive `relative`
 //! println!("{:?}", relative.to());
 //! // prints "[2, 3, 5, 8]"
@@ -35,11 +35,25 @@
 //! This currently requires Rust nightly.
 
 #![doc(html_root_url = "https://docs.rs/relative/0.1.0")]
-#![feature(used, core_intrinsics, raw, specialization)]
-#![deny(missing_docs, warnings, deprecated)]
-#![allow(intra_doc_link_resolution_failure)]
+#![feature(used, core_intrinsics, raw)]
+#![warn(
+	missing_copy_implementations,
+	missing_debug_implementations,
+	missing_docs,
+	trivial_numeric_casts,
+	unused_extern_crates,
+	unused_import_braces,
+	unused_qualifications,
+	unused_results,
+)] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
+#![cfg_attr(feature = "cargo-clippy", warn(clippy_pedantic))]
+#![cfg_attr(
+	feature = "cargo-clippy",
+	allow(inline_always, doc_markdown, trivially_copy_pass_by_ref)
+)]
 
 extern crate build_id;
+#[cfg(test)]
 extern crate metatype;
 extern crate serde;
 extern crate uuid;
@@ -54,139 +68,104 @@ extern crate serde_json;
 #[cfg(test)]
 mod tests;
 
-use std::{cmp, fmt, hash, intrinsics, marker, mem, raw};
+use std::{any, cmp, fmt, hash, intrinsics, marker, mem, raw};
 
-/// Implemented on all `T: Sized + 'static`, this provides the base memory
-/// address that `&'static T` references are (de)serialised relative to.
-pub trait Static: 'static {
-	/// Provide the base memory address that `&'static Self` references are
-	/// (de)serialised relative to.
-	fn base() -> usize;
-}
-
-/// For references into the data and BSS segments
-///
-/// The base used is a zero sized static item marked as `#[used]`.
-pub struct Data;
-#[used]
-static DATA_BASE: () = ();
-impl Static for Data {
-	#[inline(always)]
-	fn base() -> usize {
-		&DATA_BASE as *const () as usize
-	}
-}
-impl<T: 'static> Static for T {
-	#[inline(always)]
-	default fn base() -> usize {
-		Data::base()
-	}
-}
-/// For references into the code segment
-///
-/// The base used is a fn item monomorphised for `T` marked as `#[used]
-/// #[inline(never)]`.
-pub struct Code<T: ?Sized + 'static>(marker::PhantomData<fn(T)>);
-impl<T: ?Sized + 'static> Code<T> {
-	#[used]
-	#[inline(never)]
-	fn abc(_: &T) {
-		unsafe { intrinsics::unreachable() };
-	}
-}
-impl<T: ?Sized + 'static> Static for Code<T> {
-	#[inline(always)]
-	fn base() -> usize {
-		<Code<T>>::abc as fn(&T) as usize
-	}
-}
 #[doc(hidden)]
-pub struct Vtable<T: ?Sized + 'static>(marker::PhantomData<fn(T)>);
-impl<T: ?Sized + 'static> Vtable<T> {
-	#[used]
-	#[inline(never)]
-	fn abc(_: &T) {
-		unsafe { intrinsics::unreachable() };
-	}
-}
-impl<T: ?Sized + 'static> Static for Vtable<T> {
-	#[inline(always)]
-	fn base() -> usize {
-		unsafe {
-			mem::transmute::<*const Fn(&T), raw::TraitObject>(
-				&(<Vtable<T>>::abc as fn(&T)) as &Fn(&T),
-			)
-		}.vtable as usize
-	}
+#[used]
+#[no_mangle]
+pub static RELATIVE_DATA_BASE: () = ();
+
+#[doc(hidden)]
+#[no_mangle]
+#[inline(never)]
+pub fn relative_code_base() {
+	unsafe { intrinsics::unreachable() };
 }
 
-/// Wraps `&'static` references such that they can be safely sent between other
+/// This could plausibly be different in different compilation units? Else
+/// static? Else sync::Once?
+const VTABLE_BASE: *const any::Any = &() as &any::Any;
+
+/// Wraps function pointers such that they can be safely sent between other
 /// processes running the same binary.
-pub struct Pointer<T: Static>(usize, marker::PhantomData<fn(T)>);
-impl<T: Static> Pointer<T> {
+///
+/// For references into the code aka text segment.
+///
+/// The base used is the address of a function of signature:
+/// ```rust,ignore
+/// #[no_mangle]
+/// #[inline(never)]
+/// pub fn relative_code_base();
+/// ```
+pub struct Code<T: ?Sized>(usize, marker::PhantomData<fn(T)>);
+impl<T: ?Sized> Code<T> {
 	#[inline(always)]
-	fn new(p: usize) -> Pointer<T> {
-		Pointer(p, marker::PhantomData)
+	fn new(p: usize) -> Self {
+		Code(p, marker::PhantomData)
 	}
-	/// Create a `Pointer<T>` from a `&'static T`.
+	/// Create a `Code<T>` from a `*const ()`.
 	///
 	/// This is unsafe as it is up to the user to ensure the pointer lies within
 	/// static memory.
+	///
+	/// i.e. the pointer needs to be positioned the same relative to the base in
+	/// every invocation, through e.g. being in the same segment, or the binary
+	/// being statically linked.
 	#[inline(always)]
-	pub unsafe fn from(ptr: &'static T) -> Pointer<T> {
-		let base = T::base();
+	pub unsafe fn from(ptr: *const ()) -> Self {
+		let base = relative_code_base as usize;
 		// println!("from: {}: {}", base, intrinsics::type_name::<T>());
-		Pointer::new((ptr as *const T as usize).wrapping_sub(base))
+		Self::new((ptr as usize).wrapping_sub(base))
 	}
-	/// Get back a `&'static T` from a `Pointer<T>`.
+	/// Get back a `*const ()` from a `Code<T>`.
 	#[inline(always)]
-	pub fn to(&self) -> &'static T {
-		let base = T::base();
+	pub fn to(&self) -> *const () {
+		let base = relative_code_base as usize;
 		// println!("to: {}: {}", base, intrinsics::type_name::<T>());
-		unsafe { &*(base.wrapping_add(self.0) as *const T) }
+		base.wrapping_add(self.0) as *const ()
 	}
 }
-impl<T: Static> Clone for Pointer<T> {
+impl<T: ?Sized> Clone for Code<T> {
 	#[inline(always)]
 	fn clone(&self) -> Self {
-		Pointer(self.0, marker::PhantomData)
+		Code(self.0, marker::PhantomData)
 	}
 }
-impl<T: Static> Copy for Pointer<T> {}
-impl<T: Static> PartialEq for Pointer<T> {
+impl<T: ?Sized> Copy for Code<T> {}
+impl<T: ?Sized> PartialEq for Code<T> {
 	#[inline(always)]
 	fn eq(&self, other: &Self) -> bool {
 		self.0 == other.0
 	}
 }
-impl<T: Static> Eq for Pointer<T> {}
-impl<T: Static> hash::Hash for Pointer<T> {
+impl<T: ?Sized> Eq for Code<T> {}
+impl<T: ?Sized> hash::Hash for Code<T> {
 	#[inline(always)]
 	fn hash<H: hash::Hasher>(&self, state: &mut H) {
 		self.0.hash(state)
 	}
 }
-impl<T: Static> cmp::PartialOrd for Pointer<T> {
+impl<T: ?Sized> PartialOrd for Code<T> {
 	#[inline(always)]
 	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
 		self.0.partial_cmp(&other.0)
 	}
 }
-impl<T: Static> cmp::Ord for Pointer<T> {
+impl<T: ?Sized> Ord for Code<T> {
 	#[inline(always)]
 	fn cmp(&self, other: &Self) -> cmp::Ordering {
 		self.0.cmp(&other.0)
 	}
 }
-impl<T: Static> fmt::Debug for Pointer<T> {
+impl<T: ?Sized> fmt::Debug for Code<T> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		f.debug_struct("Pointer")
+		f.debug_struct("Code")
 			.field(unsafe { intrinsics::type_name::<T>() }, &self.0)
 			.finish()
 	}
 }
-impl<T: Static> serde::ser::Serialize for Pointer<T> {
-	#[inline(always)]
+impl<T: ?Sized + 'static> serde::ser::Serialize for Code<T> {
+	#[inline]
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -201,8 +180,8 @@ impl<T: Static> serde::ser::Serialize for Pointer<T> {
 		)
 	}
 }
-impl<'de, T: Static> serde::de::Deserialize<'de> for Pointer<T> {
-	#[inline(always)]
+impl<'de, T: ?Sized + 'static> serde::de::Deserialize<'de> for Code<T> {
+	#[inline]
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -212,7 +191,255 @@ impl<'de, T: Static> serde::de::Deserialize<'de> for Pointer<T> {
 				let local = build_id::get();
 				if build == local {
 					if id == unsafe { intrinsics::type_id::<T>() } {
-						Ok(Pointer::new(ptr))
+						Ok(Self::new(ptr))
+					} else {
+						Err(serde::de::Error::custom(format_args!(
+							"relative reference to wrong type ???:{}, expected {}:{}",
+							id,
+							unsafe { intrinsics::type_name::<T>() },
+							unsafe { intrinsics::type_id::<T>() }
+						)))
+					}
+				} else {
+					Err(serde::de::Error::custom(format_args!(
+						"relative reference came from a different binary {}, expected {}",
+						build, local
+					)))
+				}
+			})
+	}
+}
+
+/// Wraps `&'static` references such that they can be safely sent between other
+/// processes running the same binary.
+///
+/// For references into the data and BSS segments.
+///
+/// The base used is the address of a zero sized static item of signature:
+/// ```rust,ignore
+/// #[used]
+/// #[no_mangle]
+/// pub static RELATIVE_DATA_BASE: ();
+/// ```
+pub struct Data<T>(usize, marker::PhantomData<fn(T)>);
+impl<T> Data<T> {
+	#[inline(always)]
+	fn new(p: usize) -> Self {
+		Data(p, marker::PhantomData)
+	}
+	/// Create a `Data<T>` from a `&'static T`.
+	///
+	/// This is unsafe as it is up to the user to ensure the pointer lies within
+	/// static memory.
+	///
+	/// i.e. the pointer needs to be positioned the same relative to the base in
+	/// every invocation, through e.g. being in the same segment, or the binary
+	/// being statically linked.
+	#[inline(always)]
+	pub unsafe fn from(ptr: &'static T) -> Self {
+		let base = &RELATIVE_DATA_BASE as *const () as usize;
+		// println!("from: {}: {}", base, intrinsics::type_name::<T>());
+		Self::new((ptr as *const T as usize).wrapping_sub(base))
+	}
+	/// Get back a `&'static T` from a `Data<T>`.
+	#[inline(always)]
+	pub fn to(&self) -> &'static T {
+		let base = &RELATIVE_DATA_BASE as *const () as usize;
+		// println!("to: {}: {}", base, intrinsics::type_name::<T>());
+		unsafe { &*(base.wrapping_add(self.0) as *const T) }
+	}
+}
+impl<T> Clone for Data<T> {
+	#[inline(always)]
+	fn clone(&self) -> Self {
+		Data(self.0, marker::PhantomData)
+	}
+}
+impl<T> Copy for Data<T> {}
+impl<T> PartialEq for Data<T> {
+	#[inline(always)]
+	fn eq(&self, other: &Self) -> bool {
+		self.0 == other.0
+	}
+}
+impl<T> Eq for Data<T> {}
+impl<T> hash::Hash for Data<T> {
+	#[inline(always)]
+	fn hash<H: hash::Hasher>(&self, state: &mut H) {
+		self.0.hash(state)
+	}
+}
+impl<T> PartialOrd for Data<T> {
+	#[inline(always)]
+	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+		self.0.partial_cmp(&other.0)
+	}
+}
+impl<T> Ord for Data<T> {
+	#[inline(always)]
+	fn cmp(&self, other: &Self) -> cmp::Ordering {
+		self.0.cmp(&other.0)
+	}
+}
+impl<T> fmt::Debug for Data<T> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		f.debug_struct("Data")
+			.field(unsafe { intrinsics::type_name::<T>() }, &self.0)
+			.finish()
+	}
+}
+impl<T: 'static> serde::ser::Serialize for Data<T> {
+	#[inline]
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		<(uuid::Uuid, u64, usize) as serde::ser::Serialize>::serialize(
+			&(
+				build_id::get(),
+				unsafe { intrinsics::type_id::<T>() },
+				self.0,
+			),
+			serializer,
+		)
+	}
+}
+impl<'de, T: 'static> serde::de::Deserialize<'de> for Data<T> {
+	#[inline]
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		<(uuid::Uuid, u64, usize) as serde::de::Deserialize<'de>>::deserialize(deserializer)
+			.and_then(|(build, id, ptr)| {
+				let local = build_id::get();
+				if build == local {
+					if id == unsafe { intrinsics::type_id::<T>() } {
+						Ok(Self::new(ptr))
+					} else {
+						Err(serde::de::Error::custom(format_args!(
+							"relative reference to wrong type ???:{}, expected {}:{}",
+							id,
+							unsafe { intrinsics::type_name::<T>() },
+							unsafe { intrinsics::type_id::<T>() }
+						)))
+					}
+				} else {
+					Err(serde::de::Error::custom(format_args!(
+						"relative reference came from a different binary {}, expected {}",
+						build, local
+					)))
+				}
+			})
+	}
+}
+
+/// Wraps `&'static` references to vtables such that they can be safely sent
+/// between other processes running the same binary.
+///
+/// For references into the segment that houses the vtables, typically the
+/// read-only data segment aka rodata.
+///
+/// The base used is the vtable of a const:
+/// ```rust,ignore
+/// const VTABLE_BASE: *const any::Any = &() as &any::Any;
+/// ```
+pub struct Vtable<T: ?Sized>(usize, marker::PhantomData<fn(T)>);
+impl<T: ?Sized> Vtable<T> {
+	#[inline(always)]
+	fn new(p: usize) -> Self {
+		Vtable(p, marker::PhantomData)
+	}
+	/// Create a `Vtable<T>` from a `&'static ()`.
+	///
+	/// This is unsafe as it is up to the user to ensure the pointer lies within
+	/// static memory.
+	///
+	/// i.e. the pointer needs to be positioned the same relative to the base in
+	/// every invocation, through e.g. being in the same segment, or the binary
+	/// being statically linked.
+	#[inline(always)]
+	pub unsafe fn from(ptr: &'static ()) -> Self {
+		let base = mem::transmute::<*const any::Any, raw::TraitObject>(VTABLE_BASE).vtable as usize;
+		// println!("from: {}: {}", base, intrinsics::type_name::<T>());
+		Self::new((ptr as *const () as usize).wrapping_sub(base))
+	}
+	/// Get back a `&'static ()` from a `Vtable<T>`.
+	#[inline(always)]
+	pub fn to(&self) -> &'static () {
+		let base = unsafe { mem::transmute::<*const any::Any, raw::TraitObject>(VTABLE_BASE) }
+			.vtable as usize;
+		// println!("to: {}: {}", base, intrinsics::type_name::<T>());
+		unsafe { &*(base.wrapping_add(self.0) as *const ()) }
+	}
+}
+impl<T: ?Sized> Clone for Vtable<T> {
+	#[inline(always)]
+	fn clone(&self) -> Self {
+		Vtable(self.0, marker::PhantomData)
+	}
+}
+impl<T: ?Sized> Copy for Vtable<T> {}
+impl<T: ?Sized> PartialEq for Vtable<T> {
+	#[inline(always)]
+	fn eq(&self, other: &Self) -> bool {
+		self.0 == other.0
+	}
+}
+impl<T: ?Sized> Eq for Vtable<T> {}
+impl<T: ?Sized> hash::Hash for Vtable<T> {
+	#[inline(always)]
+	fn hash<H: hash::Hasher>(&self, state: &mut H) {
+		self.0.hash(state)
+	}
+}
+impl<T: ?Sized> PartialOrd for Vtable<T> {
+	#[inline(always)]
+	fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+		self.0.partial_cmp(&other.0)
+	}
+}
+impl<T: ?Sized> Ord for Vtable<T> {
+	#[inline(always)]
+	fn cmp(&self, other: &Self) -> cmp::Ordering {
+		self.0.cmp(&other.0)
+	}
+}
+impl<T: ?Sized> fmt::Debug for Vtable<T> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		f.debug_struct("Vtable")
+			.field(unsafe { intrinsics::type_name::<T>() }, &self.0)
+			.finish()
+	}
+}
+impl<T: ?Sized + 'static> serde::ser::Serialize for Vtable<T> {
+	#[inline]
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		<(uuid::Uuid, u64, usize) as serde::ser::Serialize>::serialize(
+			&(
+				build_id::get(),
+				unsafe { intrinsics::type_id::<T>() },
+				self.0,
+			),
+			serializer,
+		)
+	}
+}
+impl<'de, T: ?Sized + 'static> serde::de::Deserialize<'de> for Vtable<T> {
+	#[inline]
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		<(uuid::Uuid, u64, usize) as serde::de::Deserialize<'de>>::deserialize(deserializer)
+			.and_then(|(build, id, ptr)| {
+				let local = build_id::get();
+				if build == local {
+					if id == unsafe { intrinsics::type_id::<T>() } {
+						Ok(Self::new(ptr))
 					} else {
 						Err(serde::de::Error::custom(format_args!(
 							"relative reference to wrong type ???:{}, expected {}:{}",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,19 @@
+#![warn(
+	missing_copy_implementations,
+	missing_debug_implementations,
+	missing_docs,
+	trivial_numeric_casts,
+	unused_extern_crates,
+	unused_import_braces,
+	unused_qualifications,
+	unused_results,
+)] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
+#![cfg_attr(feature = "cargo-clippy", warn(clippy_pedantic))]
+#![cfg_attr(
+	feature = "cargo-clippy",
+	allow(inline_always, doc_markdown, trivially_copy_pass_by_ref)
+)]
+
 extern crate metatype;
 extern crate relative;
 #[macro_use]


### PR DESCRIPTION
switch to using single, unmonomorphised bases as this was inconsistent; only require T: 'static for (de)serialisation