### PR TITLE
Remove Code and Data

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -17,7 +17,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -36,10 +36,10 @@ pull_request_rules:
       - "title~=^WIP: .*"
     actions:
       label:
-        add: ["work-in-progress"]
+        add: ["work in progress"]
   - name: auto remove wip label
     conditions:
       - "-title~=^WIP: .*"
     actions:
       label:
-        remove: ["work-in-progress"]
+        remove: ["work in progress"]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge
@@ -21,7 +20,6 @@ pull_request_rules:
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 build_id = "0.1"
 serde = "1.0"
-uuid = { version = "0.7", features = ["serde"] }
+uuid = { version = "0.8", features = ["serde"] }
 
 [dev-dependencies]
 bincode = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
 keywords = ["serde","static","reference","pointer","distributed"]
 description = """
-A type to wrap `&'static` references such that they can be safely sent between other processes running the same binary.
+A type to wrap vtable references such that they can be safely sent between other processes running the same binary.
 """
 repository = "https://github.com/alecmocatta/relative"
 homepage = "https://github.com/alecmocatta/relative"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative"
-version = "0.1.5"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -10,7 +10,7 @@ A type to wrap `&'static` references such that they can be safely sent between o
 """
 repository = "https://github.com/alecmocatta/relative"
 homepage = "https://github.com/alecmocatta/relative"
-documentation = "https://docs.rs/relative/0.1.5"
+documentation = "https://docs.rs/relative/0.2.0"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "0.8", features = ["serde"] }
 
 [dev-dependencies]
 bincode = "1.0"
-metatype = "0.1.1"
+metatype = "0.2"
 serde_derive = "1.0"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ azure-devops = { project = "alecmocatta/relative", pipeline = "tests" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-build_id = "0.1"
+build_id = "0.2"
 serde = "1.0"
 uuid = { version = "0.8", features = ["serde"] }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/relative.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/relative/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/relative/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/relative/0.1.5)
+[Docs](https://docs.rs/relative/0.2.0)
 
 A type to wrap `&'static` references such that they can be safely sent between
 other processes running the same binary.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-08-10
+      rust_lint_toolchain: nightly-2019-10-17
       rust_flags: ''
       rust_features: ';nightly'
       rust_target_check: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ resources:
 jobs:
 - template: rust.yml@templates
   parameters:
+    endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
       rust_lint_toolchain: nightly-2019-07-19

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! This currently requires Rust nightly.
 
-#![doc(html_root_url = "https://docs.rs/relative/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/relative/0.2.0")]
 #![cfg_attr(feature = "nightly", feature(raw))]
 #![warn(
 	missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! This currently requires Rust nightly.
 
 #![doc(html_root_url = "https://docs.rs/relative/0.1.5")]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics, raw))]
+#![cfg_attr(feature = "nightly", feature(raw))]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,
@@ -47,12 +47,18 @@
 	unused_results,
 	clippy::pedantic
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
-#![allow(clippy::inline_always, clippy::trivially_copy_pass_by_ref)]
+#![allow(
+	clippy::inline_always,
+	clippy::trivially_copy_pass_by_ref,
+	clippy::must_use_candidate
+)]
 
 use serde::{
 	de::{self, Deserialize, Deserializer}, ser::{Serialize, Serializer}
 };
-use std::{any, cmp, fmt, hash, hint, marker, mem};
+use std::{
+	any::{self, type_name, TypeId}, cmp, fmt, hash, hint, marker, mem
+};
 use uuid::Uuid;
 
 #[doc(hidden)]
@@ -73,32 +79,11 @@ pub fn relative_code_base() {
 pub static RELATIVE_VTABLE_BASE: &(dyn any::Any + Sync) = &();
 
 fn type_id<T: ?Sized + 'static>() -> u64 {
-	#[cfg(feature = "nightly")]
-	{
-		unsafe { std::intrinsics::type_id::<T>() }
-	}
-	#[cfg(not(feature = "nightly"))]
-	{
-		use std::hash::{Hash, Hasher};
-		let type_id = any::TypeId::of::<T>();
-		let mut hasher = std::collections::hash_map::DefaultHasher::new();
-		type_id.hash(&mut hasher);
-		hasher.finish()
-	}
-}
-
-fn type_name<T: ?Sized>() -> &'static str {
-	#[cfg(feature = "nightly")]
-	{
-		#[allow(unused_unsafe)]
-		unsafe {
-			std::intrinsics::type_name::<T>() // TODO: std::any::type_name::<T>()
-		}
-	}
-	#[cfg(not(feature = "nightly"))]
-	{
-		"<unknown>"
-	}
+	use std::hash::{Hash, Hasher};
+	let type_id = TypeId::of::<T>();
+	let mut hasher = std::collections::hash_map::DefaultHasher::new();
+	type_id.hash(&mut hasher);
+	hasher.finish()
 }
 
 /// This is obviously a terrible no good hack to avoid requiring nightly.
@@ -136,6 +121,8 @@ impl<T: ?Sized> Code<T> {
 		Self(p, marker::PhantomData)
 	}
 	/// Create a `Code<T>` from a `*const ()`.
+	///
+	/// # Safety
 	///
 	/// This is unsafe as it is up to the user to ensure the pointer lies within
 	/// static memory.
@@ -259,6 +246,8 @@ impl<T> Data<T> {
 		Self(p, marker::PhantomData)
 	}
 	/// Create a `Data<T>` from a `&'static T`.
+	///
+	/// # Safety
 	///
 	/// This is unsafe as it is up to the user to ensure the pointer lies within
 	/// static memory.
@@ -395,6 +384,8 @@ impl<T: ?Sized> Vtable<T> {
 		Self(p, marker::PhantomData)
 	}
 	/// Create a `Vtable<T>` from a `&'static ()`.
+	///
+	/// # Safety
 	///
 	/// This is unsafe as it is up to the user to ensure the pointer lies within
 	/// static memory.


### PR DESCRIPTION
I can't see a route to guaranteed soundness for `Code` and `Data` relative pointer serialization between processes. I can see one for `Vtable`, which the compiler has more control and knowledge over. Let's focus on that.

Also:
* Update `uuid` to 0.8
* Release v0.2.0